### PR TITLE
add raw tweet download script and a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ wget-log*
 *.tar.gz
 rawTweets.txt
 apiCredentials.json
+env
+data/
+deletedTweets.txt
+rawTweets.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+wget-log*
+*.tar.gz
+rawTweets.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 wget-log*
 *.tar.gz
 rawTweets.txt
+apiCredentials.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+# Purpose: Provide simple "make" targets for developers
+
+# Default goal runs the "help" target
+.DEFAULT_GOAL := help
+
+.PHONY: download fetch-upstream
+
+help: ## Show Makefile targets
+	@printf "\033[36mUsage: make <target>\n" $$1, $$2
+	@egrep -h '\s##\s' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\t\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+download: ## Download rawTweets data file
+	@echo "Enter the following in your terminal: "
+	@echo "./scripts/dl-raw-tweets.sh [rawTweets.txt file URL] rawTweets.txt"
+
+fetch-upstream: ## Fetch any changes made to original repo
+	@./scripts/pull-from-main-project.sh
+

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,85 @@
 # Purpose: Provide simple "make" targets for developers
 
+NC := $(shell tput sgr0)
+GRN := $(shell tput setaf 2)
+RED := $(shell tput setaf 1)
+YLW := $(shell tput setaf 3)
+CYN := $(shell tput setaf 6)
+
+OK=$(GRN)[OK] $(NC)
+ERR=$(RED)[ERROR] $(NC)
+WRN=$(YLW)[WARN] $(NC)
+
+.RECIPEPREFIX = >
+GREEN = '\033[0;32M'
+VENV = env
+PYTHON = $(VENV)/bin/python3
+PIP = $(VENV)/bin/pip3
+
 # Default goal runs the "help" target
 .DEFAULT_GOAL := help
 
-.PHONY: download fetch-upstream
+.PHONY: help hello lint test cover run clean delete download fetch-upstream
 
-help: ## Show Makefile targets
-	@printf "\033[36mUsage: make <target>\n" $$1, $$2
-	@egrep -h '\s##\s' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\t\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+hello:
+> @echo "$(GRN)Welcome to your new Python virtual environment!$(NC)"
 
-download: ## Download rawTweets data file
-	@echo "Enter the following in your terminal: "
-	@echo "./scripts/dl-raw-tweets.sh [rawTweets.txt file URL] rawTweets.txt"
+## help: Show Makefile targets
+help: 
+> @ echo "Usage: make [target]\n"
+> @ sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' |  sed -e 's/^/ /'
 
-fetch-upstream: ## Fetch any changes made to original repo
-	@./scripts/pull-from-main-project.sh
+## install: Install python3-venv on host
+install: 
+> sudo apt install python3-venv -y
+> touch requirements.txt
 
+## setup: Set up project and install dependencies
+setup: requirements.txt
+> pip install virtualenv
+
+## list: List project installation dependencies
+list: requirements.txt $(VENV)
+> @$(PIP) freeze | tee requirements.txt
+
+$(VENV)/bin/activate: requirements.txt
+> @echo "$(GRN)Activating virtual environment...$(NC)"
+> @python3 -m venv $(VENV)
+> @$(PIP) install -r requirements.txt
+> @echo "$(GRN)Project requirements installed...$(NC)"
+
+## start: Activate the virtual environment
+start: $(VENV)/bin/activate
+> @echo "$(GRN)Virtual environment ready...$(NC)"
+> @echo "$(CYN)Enter the following: $(NC)"
+> @echo "$(CYN)\t. ./$(VENV)/bin/activate$(NC)"
+
+## download: Download rawTweets data file
+download: 
+> @echo "$(CYN)Enter the following in your terminal: $(NC)"
+> @echo "$(CYN)./scripts/dl-raw-tweets.sh [rawTweets.txt file URL] rawTweets.txt $(NC)"
+
+## fetch-upstream: Fetch any changes made to original repo
+fetch-upstream:
+> @./scripts/pull-from-main-project.sh
+
+## stop: Terminate the virtual environment
+stop: 
+> @echo "$(CYN)Enter the following: $(NC)"
+> @echo "$(CYN)\t deactivate$(NC)"
+
+## run: Execute the application
+run: $(VENV)/bin/activate download fetch-upstream
+> @echo "$(GRN)|======== RUNNING APPLICATION ========|$(NC)\n"
+#> @$(PYTHON) main.py
+
+## clean: Remove all build, test, coverage and Python artifact
+clean: 
+> @echo "$(YLW)Removing all unnecessary build, test, coverage and Python artifacts...$(NC)"
+> @find . -type f \( -name "*.pyc" -o -name "*.pyo" \) -exec rm -rf {} \;
+> @find . -type d -name "__pycache__" -exec rm -rf {} +
+
+## delete: Remove python virtual environment
+delete: stop clean
+> @echo "$(RED)Removing virtual environment...$(NC)"
+> rm -rf $(VENV)

--- a/dbMaintain.py
+++ b/dbMaintain.py
@@ -8,7 +8,7 @@ Created on Thu Nov 18 14:21:10 2021
 import sqlite3
 import os
 
-os.chdir(r'<INSERT PATH>')
+os.chdir(os.getcwd())
 
 conn = sqlite3.connect('de0project.db') # open the connection
 cursor = conn.cursor()

--- a/deletedTweetsdb.py
+++ b/deletedTweetsdb.py
@@ -10,8 +10,8 @@ import os
 import ast
 import sqlite3
 
-#TODO: Change to a local directory you want to store the raw txt files
-os.chdir(r'<INSERT PATH>')
+#Change to a local directory containing rawTweets.txt file
+os.chdir(os.getcwd())
 
 conn = sqlite3.connect('de0project.db') # open the connection
 cursor = conn.cursor()

--- a/dl-raw-tweets.sh
+++ b/dl-raw-tweets.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+repo_dir="$(git rev-parse --show-toplevel)"
+url=$1
+filename=$2
+
+# Functions
+usage() {
+    echo -e "Usage: \n\t$0 [url] [filename] \n"
+    exit 0
+}
+
+download_raw_tweets_file (){
+    # Download file from URL into git repo directory
+    echo -e "Downloading file from the following url:\n\t$url\n"
+
+    time wget -O $filename $url
+
+    echo -e "\nDownload complete..\nFile directory location:\n\t$repo_dir\nFiles:"
+    ls -l $repo_dir
+
+}
+
+main() {
+    # Check if help flag is supplied when invoking script
+    if [[ ( $@ == "--help" ) || $@ == "-h" ]]
+    then
+        usage
+	exit 1
+    fi
+
+    download_raw_tweets_file
+}
+
+main
+

--- a/findDeletedTweets.py
+++ b/findDeletedTweets.py
@@ -14,11 +14,11 @@ from twython import Twython, TwythonError, TwythonRateLimitError
 from datetime import datetime
 
 #TODO: Each user will have a different seed. These variables will change based on # of users
-user_seed = 0
+user_seed = 3
 count_other_users = 3
 
-#TODO: Change to a local directory you want to store the raw txt files
-os.chdir(r'Insert\Path\Here')
+#Change to a local directory containing rawTweets.txt file
+os.chdir(os.getcwd())
 
 #open up the rawfile and see how many lines (tweets) we have.
 # rawfile = open('rawTweets.txt', 'r',encoding="utf-8")

--- a/queries+analysis.py
+++ b/queries+analysis.py
@@ -20,8 +20,8 @@ def language_detector(nlp, name):
 nlp = spacy.load("en_core_web_sm")
 nlp.add_pipe('language_detector', last=True)
 
-#TODO: Change to a local directory you want to store the raw txt files
-os.chdir(r'<INSERT PATH>')
+#Change to a local directory containing rawTweets.txt file
+os.chdir(os.getcwd())
 
 conn = sqlite3.connect('de0project.db') # open the connection
 cursor = conn.cursor()

--- a/rawTweetExtract.py
+++ b/rawTweetExtract.py
@@ -12,8 +12,8 @@ import os
 import time
 from datetime import datetime
 
-#TODO: Change to a local directory you want to store the raw txt files
-os.chdir(r'<INSERT PATH>')
+#Change to a local directory containing rawTweets.txt file
+os.chdir(os.getcwd())
 
 #TODO: Change the file name to the json/text file you saved with YOUR credentials
 with open("apiCredentials.json", "r") as credsfile:

--- a/rawTweetsdb.py
+++ b/rawTweetsdb.py
@@ -10,8 +10,8 @@ import os
 import ast
 import sqlite3
 
-#TODO: Change to a local directory you want to store the raw txt files
-os.chdir(r'<INSERT PATH>')
+#Change to a local directory containing rawTweets.txt file
+os.chdir(os.getcwd())
 
 conn = sqlite3.connect('de0project.db') # open the connection
 cursor = conn.cursor()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+certifi==2021.10.8
+charset-normalizer==2.0.12
+idna==3.3
+oauthlib==3.2.0
+requests==2.27.1
+requests-oauthlib==1.3.1
+twython==3.9.1
+urllib3==1.26.9

--- a/scripts/dl-raw-tweets.sh
+++ b/scripts/dl-raw-tweets.sh
@@ -23,13 +23,14 @@ download_raw_tweets_file (){
 
 main() {
     # Check if help flag is supplied when invoking script
-    if [[ ( $@ == "--help" ) || $@ == "-h" || $# == 0 ]]
+    if [[ ( $@ == "--help" ) || $@ == "-h" ]]
     then
         usage
 	exit 1
+    else
+        download_raw_tweets_file
     fi
 
-    download_raw_tweets_file
 }
 
 main

--- a/scripts/dl-raw-tweets.sh
+++ b/scripts/dl-raw-tweets.sh
@@ -23,7 +23,7 @@ download_raw_tweets_file (){
 
 main() {
     # Check if help flag is supplied when invoking script
-    if [[ ( $@ == "--help" ) || $@ == "-h" ]]
+    if [[ ( $@ == "--help" ) || $@ == "-h" || $# == 0 ]]
     then
         usage
 	exit 1

--- a/scripts/pull-from-main-project.sh
+++ b/scripts/pull-from-main-project.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+repo_url="https://github.com/thegraey/deletedTweets.git"
+repo_dir="$(git rev-parse --show-toplevel)"
+forked_repo_name="$(basename $(git rev-parse --show-toplevel))"
+
+# Functions
+usage() {
+    echo -e "Usage: \n\t$0 \n"
+    exit 0
+}
+
+set_upstream() {
+    cd $repo_dir
+
+    echo -e "Configuring upstream git repository\n"
+    # Set upstream remote repository git repo URL if project has been forked
+    git remote add upstream $repo_url
+
+}
+
+check_mergable() {
+    # Merge changes made on original project repo into forked repo
+    git merge upstream/main $forked_repo_name > /dev/null 2>&1
+    rc=$? && echo $rc > /dev/null 2>&1
+
+    if [ "$rc" == 0 ]
+    then
+        echo -e "Attempting to merge fetched changes into forked project repo\n"
+    else
+        echo -e "No changes found in upstream git repository\n"
+    fi
+
+}
+
+main() {
+    # Check if help flag is supplied when invoking script
+    if [[ ( $@ == "--help" ) || $@ == "-h" ]]
+    then
+        usage
+	exit 1
+    fi
+
+    git remote | grep upstream > /dev/null 2>&1
+    rc=$? && echo $rc > /dev/null 2>&1
+
+    if [ "$rc" == 1 ]
+    then
+        set_upstream
+    else
+        echo "Upstream git repository has already been set"
+    fi
+
+    # Fetch changes made on original project repo
+    echo -e "Fetching changes made on original project repo\n"
+    git fetch upstream
+
+    # Check for mergable changes from original project repo 
+    check_mergable
+
+}
+
+main
+

--- a/viewMaintain.py
+++ b/viewMaintain.py
@@ -8,8 +8,8 @@ viewMaintain
 import sqlite3
 import os
 
-#TODO: Change to a local directory you want to store the raw txt files
-os.chdir(r'<INSERT PATH>')
+#Change to a local directory containing rawTweets.txt file
+os.chdir(os.getcwd())
 
 conn = sqlite3.connect('de0project.db') # open the connection
 cursor = conn.cursor()


### PR DESCRIPTION
I wrote a very basic script that can be invoked to download the raw tweet file to the local working directory of any users' git repository. The script is used as follows on a linux command line:

`./scripts/dl-raw-tweets.sh <target file url> rawTweets.txt`

This script can be used to automate the repeatable process of downloading data file dependencies stored outside of the source code repository. Down the road, when the file becomes much larger, the file can be stored in the cloud and can be written to in order to append scraped tweets.

The `.gitignore` file has been added to prevent the accidental tracking of log files produced by the `dl-raw-tweets.sh` script, and the rawTweets.txt data file that is downloaded when the `dl-raw-tweets.sh` script is executed.